### PR TITLE
Add .env.example and document usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# Application Configuration
+# Optional HTTP server port
+PORT=3000
+
+# Database Configuration
+# Optional MongoDB connection URI
+MONGODB_URI=mongodb://localhost:27017/api-gateway
+MONGODB_DB_NAME=api_gateway
+
+# AWS Cognito Configuration
+AWS_REGION=us-east-1
+AWS_COGNITO_USER_POOL_ID=
+AWS_COGNITO_CLIENT_ID=
+AWS_COGNITO_ISSUER=https://cognito-idp.us-east-1.amazonaws.com/
+
+# JWT Configuration
+JWT_SECRET=
+JWT_EXPIRES_IN=24h
+
+# Admin Panel Configuration
+ADMIN_PANEL_URL=http://localhost:3001
+SUPERADMIN_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This repository contains a Node.js based API Gateway designed for multi-tenant a
 npm install
 ```
 
+2. **Create your environment configuration**
+
+Copy `.env.example` to `.env` and update the values as needed. The template lists
+required AWS settings along with optional values such as `PORT` and `MONGODB_URI`.
+
+```bash
+cp .env.example .env
+```
+
 ## Development
 
 ```bash

--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -63,7 +63,7 @@ cd ..
 
 ### 3. Environment Configuration
 
-Create environment files for different environments:
+Create environment files for different environments using the provided `.env.example` template which lists required AWS variables (`AWS_REGION`, `AWS_COGNITO_USER_POOL_ID`, `AWS_COGNITO_CLIENT_ID`) and optional values like `PORT` and `MONGODB_URI`:
 
 ```bash
 # Create environment files


### PR DESCRIPTION
## Summary
- add `.env.example` with AWS and optional settings
- document how to copy the environment file in README
- mention the template in docs/02-getting-started

## Testing
- `npm run build` *(fails: Cannot find module 'jsonwebtoken')*
- `npm test` *(fails: Missing script "test")*