### PR TITLE
Add AWS Cognito setup script and documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ required AWS settings along with optional values such as `PORT` and `MONGODB_URI
 cp .env.example .env
 ```
 
+3. **Configure AWS Cognito**
+
+Run the setup script to create the user pool and app client. You can override the
+region, pool name and client name with environment variables:
+
+```bash
+AWS_REGION=us-east-1 \
+COGNITO_USER_POOL_NAME=my-pool \
+COGNITO_APP_CLIENT_NAME=my-client \
+./aws/setup-cognito.sh
+```
+
 ## Development
 
 ```bash

--- a/aws/setup-cognito.sh
+++ b/aws/setup-cognito.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-us-east-1}"
+USER_POOL_NAME="${COGNITO_USER_POOL_NAME:-api-gateway-users}"
+CLIENT_NAME="${COGNITO_APP_CLIENT_NAME:-api-gateway-client}"
+
+echo "Creating Cognito User Pool: $USER_POOL_NAME in $REGION"
+
+USER_POOL_ID=$(aws cognito-idp create-user-pool \
+  --region "$REGION" \
+  --pool-name "$USER_POOL_NAME" \
+  --policies '{
+    "PasswordPolicy": {
+      "MinimumLength": 8,
+      "RequireUppercase": true,
+      "RequireLowercase": true,
+      "RequireNumbers": true,
+      "RequireSymbols": false
+    }
+  }' \
+  --auto-verified-attributes email \
+  --username-attributes email \
+  --verification-message-template '{
+    "DefaultEmailOption": "CONFIRM_WITH_CODE",
+    "DefaultEmailSubject": "Your verification code",
+    "DefaultEmailMessage": "Your verification code is {####}"
+  }' \
+  --output json | jq -r '.UserPool.Id')
+
+if [[ -z "$USER_POOL_ID" ]]; then
+  echo "Failed to create user pool" >&2
+  exit 1
+fi
+
+echo "User Pool created with ID: $USER_POOL_ID"
+
+echo "Creating App Client: $CLIENT_NAME"
+
+CLIENT_ID=$(aws cognito-idp create-user-pool-client \
+  --region "$REGION" \
+  --user-pool-id "$USER_POOL_ID" \
+  --client-name "$CLIENT_NAME" \
+  --generate-secret \
+  --explicit-auth-flows ADMIN_NO_SRP_AUTH ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
+  --token-validity-units '{
+    "AccessToken": "hours",
+    "IdToken": "hours",
+    "RefreshToken": "days"
+  }' \
+  --access-token-validity 24 \
+  --id-token-validity 24 \
+  --refresh-token-validity 30 \
+  --output json | jq -r '.UserPoolClient.ClientId')
+
+if [[ -z "$CLIENT_ID" ]]; then
+  echo "Failed to create app client" >&2
+  exit 1
+fi
+
+echo "App Client created with ID: $CLIENT_ID"
+
+echo "\nCognito setup complete."
+

--- a/docs/02-getting-started.md
+++ b/docs/02-getting-started.md
@@ -129,12 +129,10 @@ docker ps
 
 #### Create Cognito User Pool
 
+Run the setup script to provision the user pool and app client:
+
 ```bash
-# Using AWS CLI (optional)
-aws cognito-idp create-user-pool \
-  --pool-name "api-gateway-users" \
-  --policies PasswordPolicy='{MinimumLength=8,RequireUppercase=true,RequireLowercase=true,RequireNumbers=true}' \
-  --auto-verified-attributes email
+./aws/setup-cognito.sh
 ```
 
 #### Manual Setup (AWS Console)

--- a/docs/03-authentication-authorization.md
+++ b/docs/03-authentication-authorization.md
@@ -8,45 +8,18 @@ AWS Cognito serves as our identity provider, handling user authentication and JW
 
 #### User Pool Setup
 
+Use the provided setup script to create the user pool.
+
 ```bash
-# Create User Pool via AWS CLI
-aws cognito-idp create-user-pool \
-  --pool-name "api-gateway-users" \
-  --policies '{
-    "PasswordPolicy": {
-      "MinimumLength": 8,
-      "RequireUppercase": true,
-      "RequireLowercase": true,
-      "RequireNumbers": true,
-      "RequireSymbols": false
-    }
-  }' \
-  --auto-verified-attributes email \
-  --username-attributes email \
-  --verification-message-template '{
-    "DefaultEmailOption": "CONFIRM_WITH_CODE",
-    "DefaultEmailSubject": "Your verification code",
-    "DefaultEmailMessage": "Your verification code is {####}"
-  }'
+./aws/setup-cognito.sh
 ```
 
 #### App Client Configuration
 
+The setup script also creates the application client for the user pool.
+
 ```bash
-# Create App Client
-aws cognito-idp create-user-pool-client \
-  --user-pool-id us-east-1_XXXXXXXXX \
-  --client-name "api-gateway-client" \
-  --generate-secret \
-  --explicit-auth-flows ADMIN_NO_SRP_AUTH ALLOW_USER_PASSWORD_AUTH ALLOW_REFRESH_TOKEN_AUTH \
-  --token-validity-units '{
-    "AccessToken": "hours",
-    "IdToken": "hours",
-    "RefreshToken": "days"
-  }' \
-  --access-token-validity 24 \
-  --id-token-validity 24 \
-  --refresh-token-validity 30
+./aws/setup-cognito.sh
 ```
 
 #### Custom Attributes for Multi-Tenancy

--- a/docs/13-troubleshooting-faq.md
+++ b/docs/13-troubleshooting-faq.md
@@ -750,30 +750,10 @@ const userAttributes = [
 
 **AWS CLI setup**:
 
-```bash
-# Create user pool
-aws cognito-idp create-user-pool \
-  --pool-name "API Gateway Users" \
-  --schema '[
-    {
-      "Name": "tenantId",
-      "AttributeDataType": "String",
-      "Mutable": true,
-      "Required": false
-    },
-    {
-      "Name": "roles",
-      "AttributeDataType": "String",
-      "Mutable": true,
-      "Required": false
-    }
-  ]'
+Instead of running the commands manually, execute the setup script:
 
-# Create app client
-aws cognito-idp create-user-pool-client \
-  --user-pool-id us-east-1_XXXXXXXXX \
-  --client-name "API Gateway Client" \
-  --generate-secret
+```bash
+./aws/setup-cognito.sh
 ```
 
 #### Q: How do I set up MongoDB for multi-tenant data isolation?


### PR DESCRIPTION
## Summary
- add `aws/setup-cognito.sh` for automated Cognito user pool and client setup
- document Cognito setup script usage in README
- reference the setup script in authentication docs
- replace manual Cognito commands in getting started guide
- update troubleshooting guide to use the new script

## Testing
- `npm run build`
